### PR TITLE
Update FUNCTIE - _crm_ledennieuwlatergevalideerd

### DIFF
--- a/FUNCTIE - _crm_ledennieuwlatergevalideerd
+++ b/FUNCTIE - _crm_ledennieuwlatergevalideerd
@@ -15,10 +15,12 @@ CREATE OR REPLACE FUNCTION public._crm_ledennieuwlatergevalideerd(
     OUT datediff_m double precision,
     OUT test_datepart numeric)
   RETURNS SETOF record AS
-$BODY$BEGIN
+$BODY$
+BEGIN
 	RETURN QUERY 
 	SELECT SQ2.check_date check_date, p.id, p.membership_start, SQ2.date_from, p.membership_nbr, SQ2.r_max, SQ2.datediff, SQ2.datediff_m
 		, date_part('month',age(SQ2.check_date::date, SQ2.date_from))::numeric test_datepart
+	--SELECT *
 	FROM 	-------------------------------------------
 		-- SQ2: MAX(r) voor total_rows() te krijgen
 		-------------------------------------------
@@ -32,11 +34,7 @@ $BODY$BEGIN
 			------------------------------------------------------------------------------------
 			SELECT i.membership_partner_id partner_id, ml.partner, ml.id, ml.date_from, ml.date_to, pp.membership_product, i.state, 
 				bs.name, bs.state, COALESCE(bs.write_date::date,aml2.last_rec_date) check_date, bs.write_date::date,
-				/*CASE
-					WHEN i.partner_id <> i.membership_partner_id AND COALESCE(a3.organisation_type_id,0) IN (1,7)  THEN 1  --1 = afdeling; 7 = regionale
-					ELSE 0
-				END via_afd,*/
-				ROW_NUMBER() OVER (PARTITION BY ml.partner ORDER BY ml.id DESC) AS r--, i.partner_id, i.membership_partner_id
+				ROW_NUMBER() OVER (PARTITION BY ml.partner ORDER BY ml.id DESC) AS r
 			--SELECT il.id, ml.account_invoice_line, i.id, il.invoice_id, aml1.move_id, i.move_id, aml2.reconcile_id, aml1.reconcile_id, bs.id, aml2.statement_id, pp.id, ml.membership_id, ml2.r
 			FROM membership_membership_line ml
 				--JOIN (SELECT ROW_NUMBER() OVER (PARTITION BY ml.partner ORDER BY ml.id DESC) AS r, ml.partner FROM membership_membership_line ml JOIN product_product pp ON pp.id = ml.membership_id WHERE pp.membership_product) ml2 ON ml2.partner = ml.partner 
@@ -56,14 +54,12 @@ $BODY$BEGIN
 				--mandaat info
 				LEFT OUTER JOIN (SELECT pb.id pb_id, pb.partner_id pb_partner_id, sm.id sm_id, sm.state sm_state FROM res_partner_bank pb JOIN sdd_mandate sm ON sm.partner_bank_id = pb.id WHERE sm.state = 'valid') sm ON pb_partner_id = ml.partner
 			WHERE pp.membership_product  AND i.state = 'paid'
-				AND NOT(COALESCE(i.sdd_mandate_id,0) = COALESCE(sm.sm_id,1) AND sm.sm_state = 'valid')
-				AND NOT( i.partner_id <> i.membership_partner_id AND COALESCE(a3.organisation_type_id,0) IN (1,7)  )
-			--AND ml.partner IN (312030)
+			--AND ml.partner IN (318392)
 			--ORDER BY ml.id ASC
 			--------------------------------------------------------------- SQ1 -
 			) SQ1
-		WHERE SQ1.r <= 2
-		GROUP BY SQ1.partner_id 
+		WHERE SQ1.r <= 2 
+		GROUP BY SQ1.partner_id
 		/*LIMIT 2*/) SQ2
 		------------------------------------- SQ2 -
 		JOIN membership_membership_line ml ON ml.id = SQ2.ml_id	
@@ -73,7 +69,7 @@ $BODY$BEGIN
 		AND ((SQ2.r_max = 1)--);
 			OR ((SQ2.r_max > 1) AND (SQ2.datediff_m <= -9 OR SQ2.datediff <= -1)));
 	 
-END; 
+END;  
 $BODY$
   LANGUAGE plpgsql VOLATILE
   COST 100


### PR DESCRIPTION
evaluatie lid via afd en lid met domi uitgeschakeld; omdat dat op lidmaatschapslijn niveau gebeurde werden lijnen uitgefilterd die nodig waren voor evaluatie nieuw lid vs bestaand lid;