### PR TITLE
20042020

### DIFF
--- a/FUNCTIE _crm_leden_factuurinfo
+++ b/FUNCTIE _crm_leden_factuurinfo
@@ -3,7 +3,8 @@
 -- DROP FUNCTION _crm_leden_factuurinfo(numeric);
 
 CREATE OR REPLACE FUNCTION _crm_leden_factuurinfo(
-    IN ml_id numeric,
+    --IN ml_id numeric,
+    OUT id integer,
     OUT factuur character varying,
     OUT ogm character varying,
     OUT bedrag numeric,
@@ -12,16 +13,18 @@ CREATE OR REPLACE FUNCTION _crm_leden_factuurinfo(
 $BODY$
 BEGIN
 	RETURN QUERY 
-	SELECT i.number, i.reference, i.amount_total, pp.name_template
+	SELECT ml.id, i.number, i.reference, i.amount_total, pp.name_template
 	FROM membership_membership_line ml
 		JOIN account_invoice_line il ON ml.account_invoice_line = il.id 
 		JOIN account_invoice i ON i.id = il.invoice_id
-		JOIN product_product pp ON pp.id = il.product_id
-	WHERE ml.id = ml_id; 
+		JOIN product_product pp ON pp.id = il.product_id;
+	--WHERE ml.id = ml_id; 
 END; 
 $BODY$
   LANGUAGE plpgsql VOLATILE
   COST 100
   ROWS 1000;
-ALTER FUNCTION _crm_leden_factuurinfo(numeric)
-  OWNER TO odbcreadonly;
+ALTER FUNCTION _crm_leden_factuurinfo()
+    OWNER TO axelvandencamp;
+GRANT EXECUTE ON FUNCTION public._crm_leden_factuurinfo() TO public;
+GRANT EXECUTE ON FUNCTION public._crm_leden_factuurinfo() TO axelvandencamp;


### PR DESCRIPTION
[membership_membership_line].[id] toegevoegd aan RETURN QUERY voor linking in queries
IN parameter verwijderd
Linking in queries moet dan op volgende manier: "JOIN _crm_leden_factuurinfo() SQ1 ON SQ1.id = ml.ml_id"
- [SQ1].[id], [SQ1].[factuur], [SQ1].[OGM], [SQ1].[bedrag], [SQ1].[product] kunnen dan weergegeven worden